### PR TITLE
[FIX] room-booking: Don't show all rooms when startHour is less than zero.

### DIFF
--- a/common/room-booking.js
+++ b/common/room-booking.js
@@ -91,8 +91,9 @@ let checkIfAllBlocked = function(startTime, endTime, cb) {
 
 let checkAvailability = function(room, booking, cb) {
   if (booking.startHour <= 9) {
-    for (i = 0; i <= booking.endHour; i++) {
+    for (i = booking.startHour; i <= booking.endHour; i++) {
       if (
+        i >=0 &&
         typeof room.fixedClasses[booking.weekDay][i] !== "undefined" &&
         room.fixedClasses[booking.weekDay][i] !== ""
       ) {

--- a/common/room-booking.js
+++ b/common/room-booking.js
@@ -93,7 +93,7 @@ let checkAvailability = function(room, booking, cb) {
   if (booking.startHour <= 9) {
     for (i = booking.startHour; i <= booking.endHour; i++) {
       if (
-        i >=0 &&
+        i >= 0 &&
         typeof room.fixedClasses[booking.weekDay][i] !== "undefined" &&
         room.fixedClasses[booking.weekDay][i] !== ""
       ) {

--- a/common/room-booking.js
+++ b/common/room-booking.js
@@ -90,8 +90,8 @@ let checkIfAllBlocked = function(startTime, endTime, cb) {
 };
 
 let checkAvailability = function(room, booking, cb) {
-  if (booking.startHour >= 0 && booking.startHour <= 9) {
-    for (i = booking.startHour; i <= booking.endHour; i++) {
+  if (booking.startHour <= 9) {
+    for (i = 0; i <= booking.endHour; i++) {
       if (
         typeof room.fixedClasses[booking.weekDay][i] !== "undefined" &&
         room.fixedClasses[booking.weekDay][i] !== ""


### PR DESCRIPTION
If startHour is less than zero (i.e time is selected as 7.00 AM), then it would never check for the clashing of classes. 
We don't need the condition to check if startHour is greater than zero or not.